### PR TITLE
fix(deck): Stop read thread when we close the deck

### DIFF
--- a/src/StreamDeck/Devices/StreamDeck.py
+++ b/src/StreamDeck/Devices/StreamDeck.py
@@ -303,6 +303,7 @@ class StreamDeck(ABC):
 
         .. seealso:: See :func:`~StreamDeck.open` for the corresponding open method.
         """
+        self.run_read_thread = False
         self.device.close()
 
     def is_open(self):


### PR DESCRIPTION
This solves the issue where StreamController crashes everytime it shuts down with the following error:

```
2025-06-25 07:58:13.555 | SUCCESS  | src.app:on_quit:197 - Stopped StreamController. Have a nice day!
StreamController: os/threads_posix.h:58: usbi_mutex_destroy: Assertion `pthread_mutex_destroy(mutex) == 0' failed.
StreamController: os/threads_posix.h:46: usbi_mutex_lock: Assertion `pthread_mutex_lock(mutex) == 0' failed.
[1]    996861 IOT instruction (core dumped)  python main.py --data data
```

The issue here is that we never told the reader thread to stop running, so it hangs and causes a SIGABRT as shown here:

```
2025-06-25 08:04:31.784 | SUCCESS  | src.app:on_quit:197 - Stopped StreamController. Have a nice day!
StreamController: os/threads_posix.h:58: usbi_mutex_destroy: Assertion `pthread_mutex_destroy(mutex) == 0' failed.
StreamController: os/threads_posix.h:46: usbi_mutex_lock: Assertion `pthread_mutex_lock(mutex) == 0' failed.
Fatal Python error: Aborted

Thread 0x00007fcd393256c0 (most recent call first):
  File "/home/devin/Projects/StreamController/.venv/lib/python3.13/site-packages/StreamDeck/Devices/StreamDeck.py", line 214 in _read_with_resume_from_suspend
  File "/usr/lib/python3.13/threading.py", line 992 in run
  File "/usr/lib/python3.13/threading.py", line 1041 in _bootstrap_inner
  File "/usr/lib/python3.13/threading.py", line 1012 in _bootstrap

Thread 0x00007fcd7a7fc6c0 (most recent call first):
  File "/home/devin/Projects/StreamController/.venv/lib/python3.13/site-packages/StreamDeck/Devices/StreamDeck.py", line 214 in _read_with_resume_from_suspend
  File "/usr/lib/python3.13/threading.py", line 992 in run
  File "/usr/lib/python3.13/threading.py", line 1041 in _bootstrap_inner
  File "/usr/lib/python3.13/threading.py", line [1]    2877051 IOT instruction (core dumped)  python -X faulthandler main.py --data data
```
