### PR TITLE
add support for Stream Deck Neo capacitive buttons

### DIFF
--- a/src/StreamDeck/Devices/StreamDeckNeo.py
+++ b/src/StreamDeck/Devices/StreamDeckNeo.py
@@ -13,9 +13,9 @@ class StreamDeckNeo(StreamDeck):
     Represents a physically attached StreamDeck Neo device.
     """
 
-    KEY_COUNT = 8
+    KEY_COUNT = 10
     KEY_COLS = 4
-    KEY_ROWS = 2
+    KEY_ROWS = 3
 
     TOUCH_KEY_COUNT = 2
 


### PR DESCRIPTION
From https://github.com/StreamController/StreamController/issues/448

---

Adds support for the Stream Deck Neo capacitive keys.

<img width="4080" height="3072" alt="image" src="https://github.com/user-attachments/assets/8a176bc3-7b97-4af4-906f-cc16e7044ded" />
