### PR TITLE
Fix Stream Deck Plus HID read length to match report descriptor

### DIFF
--- a/src/StreamDeck/Devices/StreamDeckPlus.py
+++ b/src/StreamDeck/Devices/StreamDeckPlus.py
@@ -337,8 +337,10 @@ class StreamDeckPlus(StreamDeck):
         payload[0:2] = [0x03, 0x02]
         self.device.write_feature(payload)
 
+    _INPUT_REPORT_LEN = 512
+
     def _read_control_states(self):
-        states = self.device.read(14)
+        states = self.device.read(self._INPUT_REPORT_LEN)
 
         if states is None:
             return None


### PR DESCRIPTION
## Summary
- The Stream Deck Plus USB HID report descriptor declares a **512-byte input report**, but `_read_control_states()` was reading only **14 bytes**.
- HIDAPI 0.15.0 with the **libusb backend** silently drops HID reports when the requested read size is smaller than the report descriptor's declared size.
- This breaks **dial TURN events** on real hardware (button presses still work because they arrive in shorter reports).
- Verified by capturing raw HID data: 512-byte reads return all events correctly, while 14-byte reads return no data for dial rotations.

## Changes
- Added class constant `_INPUT_REPORT_LEN = 512` to `StreamDeckPlus`, matching the USB HID report descriptor.
- Changed `self.device.read(14)` to `self.device.read(self._INPUT_REPORT_LEN)` in `_read_control_states()`.

## Test plan
- [x] Verified dial TURN events are received on real Stream Deck Plus hardware with HIDAPI 0.15.0 (libusb backend)
- [x] Verified button presses and touchscreen events continue to work correctly
- [ ] Confirm no regressions on other platforms / HIDAPI backends