### PR TITLE
Add register_controllers_factory() to support 'diy' devices

### DIFF
--- a/src/StreamDeck/DeviceManager.py
+++ b/src/StreamDeck/DeviceManager.py
@@ -5,6 +5,8 @@
 #         www.fourwalledcubicle.com
 #
 
+from collections.abc import Callable
+
 from .Devices.StreamDeck import StreamDeck
 from .Devices.StreamDeckMini import StreamDeckMini
 from .Devices.StreamDeckNeo import StreamDeckNeo
@@ -18,6 +20,32 @@ from .Devices.Mirabox293S import Mirabox293S
 from .Transport.Dummy import Dummy
 from .Transport.LibUSBHIDAPI import LibUSBHIDAPI
 from .ProductIDs import USBVendorIDs, USBProductIDs
+
+
+# Module-level registry of additional controller factories. These are intended
+# for non-USB / virtual controllers (e.g. the TouchyDeck shim) that cannot be
+# discovered via the standard USB transport. The built-in Elgato and Mirabox
+# devices are always enumerated regardless of this registry.
+_controller_factories: list[Callable[[], "list[StreamDeck]"]] = []
+
+
+def register_controllers_factory(factory: Callable[[], "list[StreamDeck]"]) -> None:
+    """
+    Register an additional controller factory whose devices are included in
+    every :meth:`DeviceManager.enumerate` call.
+
+    A factory is a zero-argument callable that returns a list of
+    :class:`StreamDeck` (or subclass) instances. Factories are intended for
+    non-USB / virtual controllers that can't be discovered via the standard
+    USB transport; the built-in Elgato and Mirabox devices are always
+    enumerated regardless.
+
+    Registration is global and cumulative. It is typically called once at
+    application startup, before any :class:`DeviceManager` is instantiated.
+
+    :param Callable factory: callable returning ``list[StreamDeck]``.
+    """
+    _controller_factories.append(factory)
 
 
 class ProbeError(Exception):
@@ -88,12 +116,15 @@ class DeviceManager:
         """
         self.transport: Transport.Transport = self._get_transport(transport)
 
-    def enumerate(self) -> list[StreamDeck]:
+    def _default_factory(self) -> list[StreamDeck]:
         """
-        Detect attached StreamDeck devices.
+        Discover the built-in, USB-attached StreamDeck controllers via this
+        manager's transport. Returns the Elgato and Mirabox devices that the
+        library knows about natively.
 
         :rtype: list(StreamDeck)
-        :return: list of :class:`StreamDeck` instances, one for each detected device.
+        :return: list of :class:`StreamDeck` instances, one for each detected
+                 USB device.
         """
 
         products = [
@@ -120,5 +151,27 @@ class DeviceManager:
         for vid, pid, class_type in products:
             found_devices = self.transport.enumerate(vid=vid, pid=pid)
             streamdecks.extend([class_type(d) for d in found_devices])
+
+        return streamdecks
+
+    def enumerate(self) -> list[StreamDeck]:
+        """
+        Detect attached StreamDeck devices, including any registered via
+        :func:`register_controllers_factory`.
+
+        Combines the built-in USB-attached devices discovered by
+        :meth:`_default_factory` with the devices returned by every
+        registered controller factory.
+
+        :rtype: list(StreamDeck)
+        :return: list of :class:`StreamDeck` instances, one for each detected
+                 device, from both the built-in USB transport and every
+                 registered controller factory.
+        """
+
+        streamdecks = list()
+        streamdecks.extend(self._default_factory())
+        for factory in _controller_factories:
+            streamdecks.extend(factory())
 
         return streamdecks


### PR DESCRIPTION
(This is needed for https://github.com/StreamController/StreamController/pull/602 - which is still a work in progress, I'll be contributing it as a plugin once this is merged and updated in pypi) 

Add a public module-level register_controllers_factory() that lets host applications register additional factories returning StreamDeck instances.

enumerate() now returns the union of the built-in USB-attached devices and the devices returned by every registered factory. This enables non-USB / virtual controllers to appear alongside real StreamDeck hardware. Fully backwards compatible: callers that register no factories see identical behaviour.

Usage:
```python
    from StreamDeck.DeviceManager import DeviceManager, register_controllers_factory

    register_controllers_factory(my_factory)  # my_factory() -> list[StreamDeck]
    decks = DeviceManager().enumerate()
```